### PR TITLE
Generate trade recommendations

### DIFF
--- a/tests/test_ai_only.py
+++ b/tests/test_ai_only.py
@@ -25,7 +25,7 @@ def test_ai_components():
     print(f"✅ Configuration loaded")
     print(f"   • Deep Research Model: {config.deep_research_model}")
     print(f"   • Primary Model: {config.primary_model}")
-    print(f"   • Market Open Time: {config.market_open_time}")
+    print(f"   • Trading Time: {config.trading_time}")
     
     # Initialize AI engine
     try:


### PR DESCRIPTION
Update test to use correct trading time attribute from config.

The `test_ai_only.py` was attempting to print `config.market_open_time`, but the `config` object available to this test used `config.trading_time`. This change aligns the test with the actual configuration attribute.

---
<a href="https://cursor.com/background-agent?bcId=bc-20fd298c-3db0-46b1-95bf-db6c69855b26">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-20fd298c-3db0-46b1-95bf-db6c69855b26">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

